### PR TITLE
Remove to_timestamp unsupported functions from Gandiva side

### DIFF
--- a/cpp/src/gandiva/function_registry_datetime.cc
+++ b/cpp/src/gandiva/function_registry_datetime.cc
@@ -165,7 +165,10 @@ std::vector<NativeFunction> GetDateTimeFunctionRegistry() {
 
       DATE_TYPES(LAST_DAY_SAFE_NULL_IF_NULL, last_day, {}),
       BASE_NUMERIC_TYPES(TO_TIME_SAFE_NULL_IF_NULL, to_time, {}),
-      BASE_NUMERIC_TYPES(TO_TIMESTAMP_SAFE_NULL_IF_NULL, to_timestamp, {})};
+      TO_TIMESTAMP_SAFE_NULL_IF_NULL(to_timestamp, {}, int32),
+      TO_TIMESTAMP_SAFE_NULL_IF_NULL(to_timestamp, {}, int64),
+      TO_TIMESTAMP_SAFE_NULL_IF_NULL(to_timestamp, {}, float32),
+      TO_TIMESTAMP_SAFE_NULL_IF_NULL(to_timestamp, {}, float64)};
 
   return date_time_fn_registry_;
 }

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -1001,7 +1001,8 @@ gdv_int64 castBIGINT_daytimeinterval(gdv_day_time_interval in) {
     return static_cast<gdv_timestamp>(seconds * MILLIS_IN_SEC); \
   }
 
-INTEGER_NUMERIC_TYPES(TO_TIMESTAMP_INTEGER)
+TO_TIMESTAMP_INTEGER(int32)
+TO_TIMESTAMP_INTEGER(int64)
 REAL_NUMERIC_TYPES(TO_TIMESTAMP_REAL)
 
 #undef TO_TIMESTAMP_INTEGER


### PR DESCRIPTION
Remove the to_timestamp for Arrow Types that are not supported by Dremio:
- INT16
- INT8
- UINT types